### PR TITLE
chore: add action update entry file version suffix

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
           release-type: node
+          token: ${{secrets.PAT}}
           package-name: '@byteinspire/inspirecloud'
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":true}]'
 

--- a/.github/workflows/update-entry-file.yml
+++ b/.github/workflows/update-entry-file.yml
@@ -1,0 +1,29 @@
+name: Update entry file version suffix
+
+on:
+  push:
+    branches:
+      - release*
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node Version 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: update package.json
+        run: node scripts/updateEntryFile.js
+
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v7.2.1
+        with:
+          add: 'package.json'
+          push: true
+          message: 'chore: update package.json browser & weapp entry file'
+
+

--- a/scripts/updateEntryFile.js
+++ b/scripts/updateEntryFile.js
@@ -5,7 +5,7 @@ function updateEntryFile() {
   let body = fs.readFileSync(`${process.cwd()}/package.json`, 'utf-8');
   body = body.replace(
     /\.\/dist\/inspirecloud-.*\.js/g,
-    `./dist/inspirecloud-${version}.js`
+    `./dist/inspirecloud.min-${version}.js`
   );
   fs.writeFileSync(`${process.cwd()}/package.json`, body);
 }

--- a/scripts/updateEntryFile.js
+++ b/scripts/updateEntryFile.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const version = require('../package.json').version;
+
+function updateEntryFile() {
+  let body = fs.readFileSync(`${process.cwd()}/package.json`, 'utf-8');
+  body = body.replace(
+    /\.\/dist\/inspirecloud-.*\.js/g,
+    `./dist/inspirecloud-${version}.js`
+  );
+  fs.writeFileSync(`${process.cwd()}/package.json`, body);
+}
+
+updateEntryFile();


### PR DESCRIPTION
目前需要每次手动更改 browser 和 weapp 的入口文件，现增加 action 进行自动更新，防止遗忘