### PR TITLE
fix: cannot find module '../package.json'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@byteinspire/js-sdk",
   "version": "0.2.2",
   "description": "inspirecloud javascript sdk",
-  "main": "./dist/node/index.js",
-  "types": "./dist/node/index.d.ts",
+  "main": "./dist/node/src/index.js",
+  "types": "./dist/node/src/index.d.ts",
   "keywords": [
     "inspirecloud",
     "InspireCloud",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -58,7 +58,8 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "package.json"],
   "exclude": ["node_modules", "test/**/*"]
 }


### PR DESCRIPTION
在 Node.js 环境下,引入`@byteinspire/js-sdk`会报错`Error: Cannot find module '../package.json'`

原因是在源码中使用`const { version } = require('../package.json');`来引入`package.json`,但却没有在`tsconfig.json`中做相应配置,导致使用 tsc 编译时,不会去处理`package.json`.

修复: 在 `tsconfig.json` 中的 `compilerOptions` 下添加 `"resolveJsonModule": true`,以及 `include` 中添加 `package.json`.
这样编译后`src/`会被映射到`dist/node/src/`,所以还需要修改`package.json`中的`main`和`types`对应的配置.